### PR TITLE
Swapped asprintf to sprintf due to a wierd bug in asprintf

### DIFF
--- a/wmr100.c
+++ b/wmr100.c
@@ -36,6 +36,7 @@
 int gOutput = OUTPUT_BOTH;
 
 /* constants */
+int const STR_BUF_SIZE = 200;
 int const RECV_PACKET_LEN   = 8;
 int const BUF_SIZE = 255;
 unsigned char const PATHLEN = 2;
@@ -260,7 +261,7 @@ void wmr_handle_rain(WMR *wmr, unsigned char *data, int len)
     int sensor, power, rate;
     float hour, day, total;
     int smi, sho, sda, smo, syr;
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
     
     sensor = data[2] & 0x0f;
     power = data[2] >> 4;
@@ -276,7 +277,7 @@ void wmr_handle_rain(WMR *wmr, unsigned char *data, int len)
     smo = data[13];
     syr = data[14] + 2000;
 
-    sprintf(msg, "type=RAIN,sensor=%d,power=%d,rate=%d,hour_total=%.2f,day_total=%.2f,all_total=%.2f,since=%04d%02d%02d%02d%02d", sensor, power, rate, hour, day, total, syr, smo, sda, sho, smi);
+    snprintf(msg, STR_BUF_SIZE, "type=RAIN,sensor=%d,power=%d,rate=%d,hour_total=%.2f,day_total=%.2f,all_total=%.2f,since=%04d%02d%02d%02d%02d", sensor, power, rate, hour, day, total, syr, smo, sda, sho, smi);
     wmr_log_data(wmr, msg);
     free(msg);
 }
@@ -290,7 +291,7 @@ void wmr_handle_temp(WMR *wmr, unsigned char *data, int len)
     float temp, dewpoint;
     char *smileyTxt = "";
     char *trendTxt = "";
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
 
     sensor = data[2] & 0x0f;
     st = data[2] >> 4;
@@ -308,7 +309,7 @@ void wmr_handle_temp(WMR *wmr, unsigned char *data, int len)
     dewpoint = (data[6] + ((data[7] & 0x0f) << 8)) / 10.0;
     if ((data[7] >> 4) == 0x8) dewpoint = -dewpoint;
     
-    sprintf(msg, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
+    snprintf(msg, STR_BUF_SIZE, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
 
     wmr_log_data(wmr, msg);
     free(msg);
@@ -318,14 +319,14 @@ void wmr_handle_water(WMR *wmr, unsigned char *data, int len)
 {
   int sensor;
   float temp;
-  char *msg = malloc(200);
+  char *msg = malloc(STR_BUF_SIZE);
 
   sensor = data[2] & 0x0f;
 
   temp = (data[3] + ((data[4] & 0x0f) << 8)) / 10.0;
   if ((data[4] >> 4) == 0x8) temp = -temp;
 
-  sprintf(msg, "type=WATER,sensor=%d,temp=%.1f", sensor, temp);
+  snprintf(msg, STR_BUF_SIZE, "type=WATER,sensor=%d,temp=%.1f", sensor, temp);
   wmr_log_data(wmr, msg);
   free(msg);
 }
@@ -333,23 +334,23 @@ void wmr_handle_water(WMR *wmr, unsigned char *data, int len)
 void wmr_handle_pressure(WMR *wmr, unsigned char *data, int len)
 {
     int pressure, forecast, alt_pressure, alt_forecast;
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
 
     pressure = data[2] + ((data[3] & 0x0f) << 8);
     forecast = data[3] >> 4;
     alt_pressure = data[4] + ((data[5] & 0x0f) << 8);
     alt_forecast = data[5] >> 4;
 
-    sprintf(msg, "type=PRESSURE,pressure=%d,forecast=%d,altpressure=%d,altforecast=%d", pressure, forecast, alt_pressure, alt_forecast);
+    snprintf(msg, STR_BUF_SIZE, "type=PRESSURE,pressure=%d,forecast=%d,altpressure=%d,altforecast=%d", pressure, forecast, alt_pressure, alt_forecast);
     wmr_log_data(wmr, msg);
     free(msg);
 }
 
 void wmr_handle_uv(WMR *wmr, unsigned char *data, int len)
 {
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
 
-    sprintf(msg, "type=UV");
+    snprintf(msg, STR_BUF_SIZE, "type=UV");
     wmr_log_data(wmr, msg);
     free(msg);
 }
@@ -358,7 +359,7 @@ char *const WINDIES[] = { "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S",
 
 void wmr_handle_wind(WMR *wmr, unsigned char *data, int len)
 {
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
     int wind_dir, power, low_speed, high_speed;
     char *wind_str;
     float wind_speed, avg_speed;
@@ -373,7 +374,7 @@ void wmr_handle_wind(WMR *wmr, unsigned char *data, int len)
     high_speed = data[6] << 4;
     avg_speed = (high_speed + low_speed) / 10.0;
 
-    sprintf(msg, "type=WIND,power=%d,dir=%s,speed=%.1f,avgspeed=%.1f", power, wind_str, wind_speed, avg_speed);
+    snprintf(msg, STR_BUF_SIZE, "type=WIND,power=%d,dir=%s,speed=%.1f,avgspeed=%.1f", power, wind_str, wind_speed, avg_speed);
     wmr_log_data(wmr, msg);
     free(msg);
 }
@@ -381,7 +382,7 @@ void wmr_handle_wind(WMR *wmr, unsigned char *data, int len)
 void wmr_handle_clock(WMR *wmr, unsigned char *data, int len)
 {
     int power, powered, battery, rf, level, mi, hr, dy, mo, yr;
-    char *msg = malloc(200);
+    char *msg = malloc(STR_BUF_SIZE);
 
     power = data[0] >> 4;
     powered = power >> 3;
@@ -395,7 +396,7 @@ void wmr_handle_clock(WMR *wmr, unsigned char *data, int len)
     mo = data[7];
     yr = data[8] + 2000;
 
-    sprintf(msg, "type=CLOCK,at=%04d%02d%02d%02d%02d,powered=%d,battery=%d,rf=%d,level=%d", yr, mo, dy, hr, mi, powered, battery, rf, level);
+    snprintf(msg, STR_BUF_SIZE, "type=CLOCK,at=%04d%02d%02d%02d%02d,powered=%d,battery=%d,rf=%d,level=%d", yr, mo, dy, hr, mi, powered, battery, rf, level);
     wmr_log_data(wmr, msg);
     free(msg);
 }


### PR DESCRIPTION
For my installation of wmr100 on my raspberry pi the asprintf functions were printing garbage even though the syntax was correct.

ie:

```
asprintf(&msg, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
```

would print mostly zeros but humidity would be a seven digit integer while

```
sprintf(msg, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
```

would print it correctly. 

Explicitly:

```
asprintf(&msg, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
    printf("%s\n",msg);
    free(msg); msg = malloc(200);
    sprintf(msg, "type=TEMP,sensor=%d,smile=%d,trend=%s,temp=%.1f,humidity=%d,dewpoint=%.1f", sensor, smiley, trendTxt, temp, humidity, dewpoint);
    printf("%s\n",msg);
```

prints

```
Receive packet len 12: 30 42 30 e0 00 36 00 30 00 30 18 02
type=TEMP,sensor=0,smile=0,trend=,temp=6.4,humidity=1076213216,dewpoint=0.0
type=TEMP,sensor=0,smile=0,trend=,temp=22.4,humidity=54,dewpoint=0.0
```

I suspect it may have something to do with the memory allocation which makes little to no sense with asprintf?
