### PR TITLE
Added fflush to stdout function

### DIFF
--- a/wmr100.c
+++ b/wmr100.c
@@ -267,6 +267,7 @@ void wmr_output_file(WMR *wmr, char *msg) {
 
 void wmr_output_stdout(WMR *wmr, char *msg) {
     printf("%s\n", msg);
+    fflush(stdout);
 }
 
 void wmr_output_zmq(WMR *wmr, char *topic, char *msg) {


### PR DESCRIPTION
Added fflush(stdout) to the wmr_output_stdout function, which helps when piping the output to another script. 

Reason: I was piping the output using popen in python and it would always hang, waiting for the buffer. 

There's probably no reason to buffer the output from time-sensitive sensor information.
