### PR TITLE
Remove linking to sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += `pkg-config libhid --cflags` -pedantic -Wall -D_GNU_SOURCE
-LIBS += `pkg-config libhid --libs` -lsqlite3 -lpthread -lzmq
+LIBS += `pkg-config libhid --libs` -lpthread -lzmq
 
 wmr100: wmr100.c
 	cc ${CFLAGS} -o wmr100 wmr100.c ${LIBS}


### PR DESCRIPTION
Sqlite functionality removed in 4bb68d99a5ac39928f56bb61a97ddc3c4bb7469e
so linking in the library is redundant.

Remove -lsqlite from the make file
